### PR TITLE
Add support for assistant market URLs for zh-TW

### DIFF
--- a/utils/AssistantMarketUrl.ts
+++ b/utils/AssistantMarketUrl.ts
@@ -4,10 +4,12 @@ class AssistantMarketUrl {
     this.baseUrl = baseUrl || ''
   }
   getIndexUrl(lang: string = 'en') {
+    if (lang === 'zh-TW') return this.baseUrl + '/index.zh-TW.json'
     if (lang.startsWith('zh')) return this.baseUrl + '/index.zh-CN.json'
     return this.baseUrl
   }
   getAssistantUrl(identifier: string, lang: string = 'en') {
+    if (lang === 'zh-TW') return this.baseUrl + `/${identifier}.zh-TW.json`
     if (lang.startsWith('zh')) return this.baseUrl + `/${identifier}.zh-CN.json`
     return this.baseUrl + `/${identifier}.json`
   }


### PR DESCRIPTION
此 PR 主要先調整可以抓取 zh-TW 助理市場資源，其餘先保持原邏輯。

> 許個願

以目前的設定來看，使用者是可以選擇系統語系，但是在撈取助理市場資源時，看起來只有明顯區分兩大塊（zh、en）。

感覺有點違和感，不曉得這一塊後續會不會有什麼改善呢？

假設我是日文的使用者，我能否看見其相對應語系的助理市場資源？

