### PR TITLE
Fixed assistant resource not found problem

### DIFF
--- a/utils/AssistantMarketUrl.ts
+++ b/utils/AssistantMarketUrl.ts
@@ -9,9 +9,9 @@ class AssistantMarketUrl {
     return this.baseUrl + '/index.' + lang + '.json'
   }
   getAssistantUrl(identifier: string, lang: string = 'en-US') {
-    if (lang === 'en-US') return this.baseUrl + '/' + identifier + '/index.json'
-    if (lang === 'ar-SA') return this.baseUrl + '/' + identifier + '/index.ar.json'
-    return this.baseUrl + '/' + identifier + '/index.' + lang + '.json'
+    if (lang === 'en-US') return this.baseUrl + '/' + identifier + '.json'
+    if (lang === 'ar-SA') return this.baseUrl + '/' + identifier + '.ar.json'
+    return this.baseUrl + '/' + identifier + '.' + lang + '.json'
   }
 }
 


### PR DESCRIPTION
現行抓取助理資源如下

> https://registry.npmmirror.com/@lobehub/agents-index/1.42.0/files/public/food-reviewer/index.zh-TW.json

正確應如下

> https://registry.npmmirror.com/@lobehub/agents-index/1.42.0/files/public/food-reviewer.zh-TW.json

`1.10.4` 版才有出現這個問題，已有初步修正，可以再確認看看有沒有什麼漏改的。