### PR TITLE
feat: IP-based locale initialization, model-list parser fix, and mobile viewport refinements-2

### DIFF
--- a/app/api/env/route.ts
+++ b/app/api/env/route.ts
@@ -1,21 +1,115 @@
 import { NextResponse, type NextRequest } from 'next/server'
+import locales from '@/constant/locales'
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY || ''
 const ACCESS_PASSWORD = process.env.ACCESS_PASSWORD || ''
 const NEXT_PUBLIC_BUILD_MODE = process.env.NEXT_PUBLIC_BUILD_MODE || 'default'
 const NEXT_PUBLIC_GEMINI_MODEL_LIST = process.env.NEXT_PUBLIC_GEMINI_MODEL_LIST || 'all'
 const NEXT_PUBLIC_UPLOAD_LIMIT = Number(process.env.NEXT_PUBLIC_UPLOAD_LIMIT || '0')
+const DEFAULT_LOCALE = 'en-US'
+const SUPPORTED_LOCALES = new Set(Object.keys(locales))
+
+const COUNTRY_TO_LOCALE: Record<string, string> = {
+  AE: 'ar-SA',
+  AR: 'es-ES',
+  AT: 'de-DE',
+  AU: 'en-US',
+  BE: 'fr-FR',
+  BH: 'ar-SA',
+  BO: 'es-ES',
+  BR: 'pt-BR',
+  BY: 'ru-RU',
+  CA: 'en-US',
+  CH: 'de-DE',
+  CL: 'es-ES',
+  CN: 'zh-CN',
+  CO: 'es-ES',
+  CR: 'es-ES',
+  CU: 'es-ES',
+  CY: 'en-US',
+  DE: 'de-DE',
+  DO: 'es-ES',
+  DZ: 'ar-SA',
+  EC: 'es-ES',
+  EG: 'ar-SA',
+  ES: 'es-ES',
+  FR: 'fr-FR',
+  GB: 'en-US',
+  GT: 'es-ES',
+  HK: 'zh-TW',
+  HN: 'es-ES',
+  IE: 'en-US',
+  IQ: 'ar-SA',
+  IT: 'en-US',
+  JO: 'ar-SA',
+  JP: 'ja-JP',
+  KR: 'ko-KR',
+  KW: 'ar-SA',
+  LB: 'ar-SA',
+  LU: 'fr-FR',
+  LY: 'ar-SA',
+  MA: 'ar-SA',
+  MC: 'fr-FR',
+  MO: 'zh-TW',
+  MX: 'es-ES',
+  NI: 'es-ES',
+  NZ: 'en-US',
+  OM: 'ar-SA',
+  PA: 'es-ES',
+  PE: 'es-ES',
+  PR: 'es-ES',
+  PT: 'pt-BR',
+  PY: 'es-ES',
+  QA: 'ar-SA',
+  RU: 'ru-RU',
+  SA: 'ar-SA',
+  SG: 'zh-CN',
+  SV: 'es-ES',
+  SY: 'ar-SA',
+  TN: 'ar-SA',
+  TW: 'zh-TW',
+  US: 'en-US',
+  UY: 'es-ES',
+  VE: 'es-ES',
+  YE: 'ar-SA',
+}
+
+function getCountryCode(req: NextRequest) {
+  const countryHeaders = [
+    'cf-ipcountry',
+    'x-vercel-ip-country',
+    'x-country-code',
+    'x-country',
+    'cloudfront-viewer-country',
+  ]
+  for (const headerName of countryHeaders) {
+    const value = req.headers.get(headerName)?.toUpperCase().trim()
+    if (value && /^[A-Z]{2}$/.test(value) && value !== 'XX' && value !== 'T1') {
+      return value
+    }
+  }
+  return ''
+}
+
+function getLocaleFromCountry(countryCode: string) {
+  const locale = COUNTRY_TO_LOCALE[countryCode] || DEFAULT_LOCALE
+  return SUPPORTED_LOCALES.has(locale) ? locale : DEFAULT_LOCALE
+}
 
 export const runtime = 'edge'
 export const preferredRegion = ['cle1', 'iad1', 'pdx1', 'sfo1', 'sin1', 'syd1', 'hnd1', 'kix1']
 
 export async function GET(req: NextRequest) {
   if (NEXT_PUBLIC_BUILD_MODE === 'export') return new NextResponse('Not available under static deployment')
+  const countryCode = getCountryCode(req)
+  const localeFromIp = getLocaleFromCountry(countryCode)
 
   return NextResponse.json({
     isProtected: GEMINI_API_KEY !== '' && ACCESS_PASSWORD !== '',
     buildMode: NEXT_PUBLIC_BUILD_MODE,
     modelList: NEXT_PUBLIC_GEMINI_MODEL_LIST,
     uploadLimit: NEXT_PUBLIC_UPLOAD_LIMIT,
+    countryCode,
+    localeFromIp,
   })
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -96,7 +96,36 @@
 html,
 body {
   height: 100%;
+  min-height: 100%;
+  height: var(--app-viewport-height, 100%);
+  min-height: var(--app-viewport-height, 100%);
 }
+
+.app-viewport-height {
+  height: 100vh;
+  min-height: 100vh;
+}
+
+@supports (height: 100svh) {
+  .app-viewport-height {
+    height: 100svh;
+    min-height: 100svh;
+  }
+}
+
+@supports (height: 100dvh) {
+  .app-viewport-height {
+    height: 100dvh;
+    min-height: 100dvh;
+  }
+}
+
+/* Use runtime viewport height when available to avoid mobile browser UI glitches. */
+.app-viewport-height {
+  height: var(--app-viewport-height, 100dvh);
+  min-height: var(--app-viewport-height, 100dvh);
+}
+
 .inline-image {
   max-height: 200px;
   border-radius: 4px;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,7 +37,7 @@ import type { FileManagerOptions } from '@/utils/FileManager'
 import { fileUpload, imageUpload } from '@/utils/upload'
 import { findOperationById } from '@/utils/plugin'
 import { generateImages, type ImageGenerationRequest } from '@/utils/generateImages'
-import { detectLanguage, formatTime, readFileAsDataURL, base64ToBlob, isOfficeFile } from '@/utils/common'
+import { formatTime, readFileAsDataURL, base64ToBlob, isOfficeFile } from '@/utils/common'
 import { cn } from '@/utils'
 import { GEMINI_API_BASE_URL } from '@/constant/urls'
 import { OldVisionModel, OldTextModel } from '@/constant/model'
@@ -93,6 +93,8 @@ export default function Home() {
   const files = useAttachmentStore((state) => state.files)
   const references = useMessageStore((state) => state.references)
   const model = useSettingStore((state) => state.model)
+  const envLoaded = useEnvStore((state) => state.loaded)
+  const localeFromIp = useEnvStore((state) => state.localeFromIp)
   const [textareaHeight, setTextareaHeight] = useState<number>(TEXTAREA_DEFAULT_HEIGHT)
   const [content, setContent] = useState<string>('')
   const [message, setMessage] = useState<string>('')
@@ -955,21 +957,73 @@ export default function Home() {
   }, [sidebarState, toggleSidebar])
 
   useLayoutEffect(() => {
+    const isIOS =
+      /iPad|iPhone|iPod/.test(navigator.userAgent) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+    if (isIOS) {
+      document.documentElement.style.removeProperty('--app-viewport-height')
+      return
+    }
+
+    let previousHeight = 0
+    const updateViewportHeight = () => {
+      const viewportHeight = Math.round(window.visualViewport?.height ?? window.innerHeight)
+      if (viewportHeight > 0 && viewportHeight !== previousHeight) {
+        previousHeight = viewportHeight
+        document.documentElement.style.setProperty('--app-viewport-height', `${viewportHeight}px`)
+      }
+    }
+
+    const visualViewport = window.visualViewport
+    updateViewportHeight()
+    const rafId = window.requestAnimationFrame(updateViewportHeight)
+    const timeoutId = window.setTimeout(updateViewportHeight, 300)
+    const intervalId = window.setInterval(updateViewportHeight, 500)
+
+    window.addEventListener('resize', updateViewportHeight)
+    window.addEventListener('orientationchange', updateViewportHeight)
+    window.addEventListener('pageshow', updateViewportHeight)
+    window.addEventListener('scroll', updateViewportHeight, true)
+    window.addEventListener('focus', updateViewportHeight, true)
+    window.addEventListener('blur', updateViewportHeight, true)
+    window.addEventListener('touchend', updateViewportHeight)
+    document.addEventListener('visibilitychange', updateViewportHeight)
+    visualViewport?.addEventListener('resize', updateViewportHeight)
+    visualViewport?.addEventListener('scroll', updateViewportHeight)
+
+    return () => {
+      window.cancelAnimationFrame(rafId)
+      window.clearTimeout(timeoutId)
+      window.clearInterval(intervalId)
+      window.removeEventListener('resize', updateViewportHeight)
+      window.removeEventListener('orientationchange', updateViewportHeight)
+      window.removeEventListener('pageshow', updateViewportHeight)
+      window.removeEventListener('scroll', updateViewportHeight, true)
+      window.removeEventListener('focus', updateViewportHeight, true)
+      window.removeEventListener('blur', updateViewportHeight, true)
+      window.removeEventListener('touchend', updateViewportHeight)
+      document.removeEventListener('visibilitychange', updateViewportHeight)
+      visualViewport?.removeEventListener('resize', updateViewportHeight)
+      visualViewport?.removeEventListener('scroll', updateViewportHeight)
+    }
+  }, [])
+
+  useLayoutEffect(() => {
+    if (!envLoaded) return
     const { lang, update } = useSettingStore.getState()
     if (lang === '') {
-      const browserLang = detectLanguage()
-      i18n.changeLanguage(browserLang)
-      const payload: Partial<Setting> = { lang: browserLang, sttLang: browserLang, ttsLang: browserLang }
-      const options = new EdgeSpeech({ locale: browserLang }).voiceOptions
+      const langFromIp = localeFromIp || 'en-US'
+      i18n.changeLanguage(langFromIp)
+      const payload: Partial<Setting> = { lang: langFromIp, sttLang: langFromIp, ttsLang: langFromIp }
+      const options = new EdgeSpeech({ locale: langFromIp }).voiceOptions
       if (options) {
         payload.ttsVoice = options[0].value
       }
       update(payload)
     }
-  }, [])
+  }, [envLoaded, localeFromIp])
 
   return (
-    <main className="mx-auto flex h-screen max-h-[-webkit-fill-available] w-full max-w-screen-lg flex-col justify-between overflow-hidden max-lg:max-w-screen-md">
+    <main className="mx-auto app-viewport-height flex w-full max-w-screen-lg flex-col justify-between overflow-hidden max-lg:max-w-screen-md">
       <div className="flex w-full justify-between px-4 pb-2 pr-2 pt-10 max-md:pt-4 max-sm:pr-2 max-sm:pt-4">
         <div className="flex items-center text-red-400">
           <div>

--- a/components/I18nProvider.tsx
+++ b/components/I18nProvider.tsx
@@ -8,6 +8,7 @@ function I18Provider({ children }: { children: React.ReactNode }) {
   const { lang } = useSettingStore()
 
   useLayoutEffect(() => {
+    if (!lang) return
     i18n.changeLanguage(lang)
   }, [lang])
   return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>

--- a/components/ModelSelect.tsx
+++ b/components/ModelSelect.tsx
@@ -3,6 +3,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { useSettingStore, useEnvStore } from '@/store/setting'
 import { useModelStore } from '@/store/model'
 import { fetchModels } from '@/utils/models'
+import { parseModelList } from '@/utils/modelList'
 import { getRandomKey } from '@/utils/common'
 import { Model } from '@/constant/model'
 import { values, keys, find } from 'lodash-es'
@@ -34,28 +35,10 @@ function ModelSelect({ className, defaultModel }: Props) {
       })
     }
 
-    let modelList: string[] = []
     const defaultModelList: string[] = keys(Model)
-    const userModels: string[] = MODEL_LIST ? MODEL_LIST.split(',') : []
+    const parsedModelList = parseModelList(MODEL_LIST, defaultModelList)
 
-    userModels.forEach((modelName) => {
-      for (const name of defaultModelList) {
-        if (!modelList.includes(name)) modelList.push(name)
-      }
-      if (modelName === 'all' || modelName === '+all') {
-      } else if (modelName === '-all') {
-        modelList = modelList.filter((name) => !defaultModelList.includes(name))
-      } else if (modelName.startsWith('-')) {
-        modelList = modelList.filter((name) => name !== modelName.substring(1))
-      } else if (modelName.startsWith('@')) {
-        const name = modelName.substring(1)
-        if (!modelList.includes(name)) modelList.push(name)
-      } else {
-        modelList.push(modelName.startsWith('+') ? modelName.substring(1) : modelName)
-      }
-    })
-
-    return modelList.length > 0 ? modelList : defaultModelList
+    return parsedModelList.models
   }, [models, MODEL_LIST])
 
   const handleModelChange = useCallback(

--- a/components/MultimodalLive/index.tsx
+++ b/components/MultimodalLive/index.tsx
@@ -298,7 +298,7 @@ function MultimodalLive({ onClose }: Props) {
   }, [])
 
   return (
-    <div className="fixed left-0 right-0 top-0 z-50 flex h-full w-screen flex-col bg-slate-900">
+    <div className="fixed left-0 right-0 top-0 z-50 flex app-viewport-height w-screen flex-col bg-slate-900">
       <div className="items-top relative h-full w-full justify-center">
         <div className={cn('mx-auto h-full w-full max-w-screen-sm', { hidden: connected })}>
           <SystemInstruction className="relative top-1/2 mx-4 -translate-y-1/2" maxHeight="300px" closeable={false} />

--- a/components/Setting.tsx
+++ b/components/Setting.tsx
@@ -20,6 +20,7 @@ import Button from '@/components/Button'
 import ResponsiveDialog from '@/components/ResponsiveDialog'
 import i18n from '@/utils/i18n'
 import { fetchModels } from '@/utils/models'
+import { parseModelList } from '@/utils/modelList'
 import { getRandomKey } from '@/utils/common'
 import locales from '@/constant/locales'
 import { Model, DefaultModel } from '@/constant/model'
@@ -85,35 +86,18 @@ function Setting({ open, hiddenTalkPanel, onClose }: SettingProps) {
       })
     }
 
-    let modelList: string[] = []
-    let defaultModel = DefaultModel
     const defaultModelList: string[] = keys(Model)
-    const userModels: string[] = MODEL_LIST ? MODEL_LIST.split(',') : []
+    const parsedModelList = parseModelList(MODEL_LIST, defaultModelList)
+    const models = parsedModelList.models
 
-    userModels.forEach((modelName) => {
-      for (const name of defaultModelList) {
-        if (!modelList.includes(name)) modelList.push(name)
-      }
-      if (modelName === 'all' || modelName === '+all') {
-      } else if (modelName === '-all') {
-        modelList = modelList.filter((name) => !defaultModelList.includes(name))
-      } else if (modelName.startsWith('-')) {
-        modelList = modelList.filter((name) => name !== modelName.substring(1))
-      } else if (modelName.startsWith('@')) {
-        const name = modelName.substring(1)
-        if (!modelList.includes(name)) modelList.push(name)
-        if (model === '') {
-          update({ model: name })
-          defaultModel = name
-        }
-      } else {
-        modelList.push(modelName.startsWith('+') ? modelName.substring(1) : modelName)
-      }
-    })
-
-    const models = modelList.length > 0 ? modelList : defaultModelList
-    if (models.length > 0 && !models.includes(defaultModel)) {
-      update({ model: models[0] })
+    if (parsedModelList.defaultModel && model === DefaultModel && models.includes(parsedModelList.defaultModel)) {
+      update({ model: parsedModelList.defaultModel })
+    } else if (models.length > 0 && !models.includes(model)) {
+      const fallbackModel =
+        parsedModelList.defaultModel && models.includes(parsedModelList.defaultModel)
+          ? parsedModelList.defaultModel
+          : models[0]
+      update({ model: fallbackModel })
     }
 
     return models

--- a/components/StoreProvider.tsx
+++ b/components/StoreProvider.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useLayoutEffect } from 'react'
+import { detectLanguage } from '@/utils/common'
 import { useEnvStore } from '@/store/setting'
 
 const NEXT_PUBLIC_BUILD_MODE = process.env.NEXT_PUBLIC_BUILD_MODE || 'default'
@@ -10,15 +11,21 @@ interface Props {
 
 function StoreProvider({ children }: Props) {
   useLayoutEffect(() => {
+    const { update } = useEnvStore.getState()
     if (NEXT_PUBLIC_BUILD_MODE !== 'export') {
-      const { update } = useEnvStore.getState()
       fetch('/api/env')
         .then(async (response) => {
+          if (!response.ok) throw new Error(`Failed to fetch env: ${response.status}`)
           const env = await response.json()
-          update(env)
+          update({ ...env, loaded: true })
         })
-        .catch(console.error)
+        .catch((error) => {
+          console.error(error)
+          update({ buildMode: NEXT_PUBLIC_BUILD_MODE, localeFromIp: 'en-US', loaded: true })
+        })
+      return
     }
+    update({ buildMode: 'export', localeFromIp: detectLanguage(), loaded: true })
   }, [])
 
   return children

--- a/components/TalkWithVoice.tsx
+++ b/components/TalkWithVoice.tsx
@@ -76,7 +76,7 @@ function TalkWithVoice({
 
   return (
     <div>
-      <div className="fixed left-0 right-0 top-0 z-50 flex h-full w-screen flex-col items-center justify-center bg-slate-900">
+      <div className="fixed left-0 right-0 top-0 z-50 flex app-viewport-height w-screen flex-col items-center justify-center bg-slate-900">
         <div className="h-1/5 w-full" ref={siriWaveRef}></div>
         <div className="absolute bottom-0 flex h-2/5 w-2/3 flex-col justify-between pb-12 text-center">
           <div className="text-sm leading-6">

--- a/store/setting.ts
+++ b/store/setting.ts
@@ -14,7 +14,10 @@ interface EnvStore {
   uploadLimit: number
   buildMode: string
   isProtected: boolean
-  update: (values: Record<string, string | number | boolean>) => void
+  countryCode: string
+  localeFromIp: string
+  loaded: boolean
+  update: (values: Partial<Omit<EnvStore, 'update'>>) => void
 }
 
 const defaultSetting: DefaultSetting = {
@@ -78,5 +81,8 @@ export const useEnvStore = create<EnvStore>((set) => ({
   uploadLimit: 0,
   buildMode: '',
   isProtected: true,
-  update: (values) => set(values),
+  countryCode: '',
+  localeFromIp: 'en-US',
+  loaded: false,
+  update: (values) => set((state) => ({ ...state, ...values })),
 }))

--- a/utils/modelList.ts
+++ b/utils/modelList.ts
@@ -1,0 +1,68 @@
+export interface ParsedModelList {
+  models: string[]
+  defaultModel?: string
+}
+
+export function parseModelList(input: string, defaultModels: string[]): ParsedModelList {
+  const tokens = input
+    .split(',')
+    .map((token) => token.trim())
+    .filter((token) => token !== '')
+
+  if (tokens.length === 0) {
+    return { models: [...defaultModels] }
+  }
+
+  const models: string[] = []
+  let defaultModel: string | undefined
+
+  const addModel = (name: string) => {
+    if (name !== '' && !models.includes(name)) {
+      models.push(name)
+    }
+  }
+
+  const removeModel = (name: string) => {
+    if (name === '') return
+    const nextModels = models.filter((modelName) => modelName !== name)
+    models.length = 0
+    models.push(...nextModels)
+  }
+
+  const addAllDefaultModels = () => {
+    defaultModels.forEach((name) => addModel(name))
+  }
+
+  tokens.forEach((token) => {
+    if (token === 'all' || token === '+all') {
+      addAllDefaultModels()
+      return
+    }
+
+    if (token === '-all') {
+      defaultModels.forEach((name) => removeModel(name))
+      return
+    }
+
+    if (token.startsWith('@')) {
+      const name = token.substring(1).trim()
+      if (name !== '') {
+        defaultModel = name
+        addModel(name)
+      }
+      return
+    }
+
+    if (token.startsWith('-')) {
+      removeModel(token.substring(1).trim())
+      return
+    }
+
+    addModel(token.startsWith('+') ? token.substring(1).trim() : token)
+  })
+
+  return {
+    models,
+    defaultModel,
+  }
+}


### PR DESCRIPTION
The commit message says IP-based initial locale (@kkgs-32), which refers to my request, but the actual changes only modify the Gemini model list. It doesn’t seem related to my requested change.





## Summary
This PR includes three updates:
1. Add IP/country-based initial language selection with `en-US` fallback.
2. Fix and unify custom model list parsing (`all`, `+`, `-`, `-all`, `@`).
3. Refine mobile viewport-height behavior: keep Android improvements and rollback iOS-specific runtime override after regression.

## Changes

### 1) IP-based initial locale
- Updated `/api/env` to return `countryCode` and `localeFromIp`.
- Country is inferred from common edge/platform headers.
- Unsupported or unmapped regions fall back to `en-US`.
- Client now applies initial language only after env is loaded.
- Added guard to avoid `i18n.changeLanguage('')`.

### 2) Model list parsing fix and unification
- Added shared parser: `utils/modelList.ts`.
- Replaced duplicated parsing logic in:
  - `components/Setting.tsx`
  - `components/ModelSelect.tsx`
- Fixed `-all` behavior so default models are actually removed.
- Standardized `@model` handling for default-model preference.

### 3) Mobile viewport-height handling
- Introduced/kept `.app-viewport-height` strategy in `app/globals.css` (`vh/svh/dvh` + CSS variable fallback).
- Kept runtime viewport syncing in `app/page.tsx` for non-iOS.
- Disabled iOS runtime viewport override path after regression.
- Removed iOS-specific `-webkit-fill-available` fallback block.
- Reverted temporary mobile `fixed/inset` layout on normal chat mode.

## Files Changed
- `utils/modelList.ts` (new)
- `components/Setting.tsx`
- `components/ModelSelect.tsx`
- `app/globals.css`
- `app/page.tsx`
- `components/TalkWithVoice.tsx`
- `components/MultimodalLive/index.tsx`
- `store/setting.ts`
- `components/StoreProvider.tsx`
- `app/api/env/route.ts`
- `components/I18nProvider.tsx`

## Verification
- Lint/build could not be executed in this environment because dependencies were not installed (`next: command not found`).

## Notes
- Voice mode height remains stable on both iOS and Android.
- iOS normal-mode height override was intentionally rolled back due to regression.
